### PR TITLE
troll warren victory event fix

### DIFF
--- a/events/enc_events_reformers.txt
+++ b/events/enc_events_reformers.txt
@@ -10206,6 +10206,14 @@ news_event = { #335 - WBH Crushed
 		TRL = {
 			set_technology = {
 				settled_civilization = 1
+				habitation_tech_level_settler = 1
+				electronics_tech_level_settler = 1
+				tools_tech_level_settler = 1
+				infantry_tech_level_settler = 1
+				support_tech_level_settler = 1
+				special_forces_tech_level_settler = 1
+				air_tech_level_tribal = 1
+				air_tech_level_settler = 1
 			}
 		}
 	}


### PR DESCRIPTION
edited troll warren victory over capitol hill event so that now it actually gives them buffs for tech lvl which it did not previously do due to the changes on how tech works after legion patch