### PR TITLE
las-fix treaty of hoover dam for nevada

### DIFF
--- a/common/decisions/enc_reform_decisions.txt
+++ b/common/decisions/enc_reform_decisions.txt
@@ -2204,6 +2204,10 @@ ENC_treaty_hoover_dam = {
 					add_core_of = ERB
 					remove_core_of = NCR			
 				}	
+				526 = {
+					add_core_of = ERB
+					remove_core_of = NCR			
+				}	
 			}
 
 			every_owned_state = {

--- a/common/national_focus/erb_nf.txt
+++ b/common/national_focus/erb_nf.txt
@@ -4307,6 +4307,11 @@ focus = {#Legion Border
 				add_state_core = 210
 				add_state_core = 573
 				add_state_core = 273
+				add_state_core = 67
+				add_state_core = 13
+				add_state_core = 592
+				add_state_core = 526
+				add_state_core = 118
 			}
 
 			custom_effect_tooltip = break_line


### PR DESCRIPTION
fixed what states are shuffeled around with  treaty of hoover dam returning proper cores to nevada and ncr